### PR TITLE
Make renderPage middleware to serve pages

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,6 +1,6 @@
 {
   "port": 3000,
-  "title": "Hello World",
+  "title": "React App",
   "trustProxy": true,
   "logging": {
     "format": "combined",

--- a/src/reducers/rootReducer.js
+++ b/src/reducers/rootReducer.js
@@ -6,9 +6,12 @@ const DEFAULT_STATE = {
   test: testReducerState,
 };
 
-export const initialState = typeof window !== 'undefined' && Object.keys(window.__PRELOADED_STATE__) > 0
-  ? JSON.parse(window.__PRELOADED_STATE__)
-  : DEFAULT_STATE;
+let defaultState = DEFAULT_STATE;
+if (typeof window !== 'undefined' && window.__PRELOADED_STATE__) {
+  defaultState = JSON.parse(window.__PRELOADED_STATE__);
+}
+
+export { defaultState as initialState };
 
 export default combineReducers({
   test: testReducer,

--- a/src/server/ExpressServer.js
+++ b/src/server/ExpressServer.js
@@ -8,6 +8,7 @@ import shortstopRegex from 'shortstop-regex';
 import bodyParser from 'body-parser';
 import enrouten from 'express-enrouten';
 import 'fetch-everywhere';
+import renderPage from './middleware/renderPage'
 
 function betterRequire(basePath) {
   const baseRequire = handlers.require(basePath);
@@ -91,6 +92,8 @@ export default class ExpressServer {
     if (middleware) {
       this.app.use(meddleware(middleware));
     }
+
+    this.app.use(renderPage());
 
     return new Promise((resolve, reject) => {
       this.server.listen(config.get('port'), resolve);

--- a/src/server/middleware/renderPage.js
+++ b/src/server/middleware/renderPage.js
@@ -1,0 +1,24 @@
+export default function () {
+  return function renderPage (req, res, next) {
+    const manifest = require(`${process.cwd()}/dist/webpack/manifest.json`);
+
+    res.send(`
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta charset="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, maximum-scale=1" />
+          <link rel="stylesheet" href="/${manifest['client.css']}" />
+          <title>${req.config.get('title')}</title>
+          <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" crossorigin="anonymous" />
+        </head>
+        <body>
+          <div id="root"></div>
+          <script type="text/javascript" src="/${manifest['vendor.js']}"></script>
+          <script type="text/javascript" src="/${manifest['client.js']}"></script>
+          <script src="https://unpkg.com/react-bootstrap@next/dist/react-bootstrap.min.js" crossorigin />
+        </body>
+      </html>
+    `);
+  }
+}

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -1,43 +1,4 @@
-import React from 'react';
-import ReactDOMServer from 'react-dom/server';
-import { Provider } from 'react-redux';
-import { StaticRouter } from 'react-router-dom';
-import Router from '../../components/router';
-import getInitialHtml from '../../lib/utils/getInitialHtml';
-import { DEFAULT_STATE } from '../../reducers/rootReducer';
-import createStore from '../../client/store';
-
 export default async function index(router) {
-  router.get('*', async (req, res, next) => {
-    if (req.method.toLowerCase() === 'get' && req.headers['Content-Type'] !== 'application/json') {
-      const BUILD_DIRECTORY = `${process.cwd()}/dist`;
-      const manifest = require(`${BUILD_DIRECTORY}/webpack/manifest.json`);
-
-      const context = {};
-      if (context.url) {
-        res.redirect(context.url);
-        return;
-      }
-
-      const store = createStore(DEFAULT_STATE);
-      const content = ReactDOMServer.renderToString(
-        <StaticRouter location={req.url} context={context}>
-          <Provider store={store}>
-            <Router />
-          </Provider>
-        </StaticRouter>
-      );
-
-      if (context.url) {
-        res.redirect(context.url);
-      } else {
-        res.status(200).send(getInitialHtml(content, manifest, store.getState()));
-      }
-    }
-
-    next();
-  });
-
   router.get('/', async (req, res, next) => {
     next();
   });


### PR DESCRIPTION
In place of catch-all route to serve react / initial html, use middleware to do the job.